### PR TITLE
clean up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"


### PR DESCRIPTION
- format yml file to be consistent (all strings wrapped in double quotes)
- drop number of open pull requests to default 5 to keep pull requests tab clean (it only limits number of opened prs, dependabot prepares all the branches on the interval mark and once number of opened pull requests goes down it opens up new ones for the existing branches)
- add docker configuration