### PR TITLE
allow wildcard sponsored dnslink domains

### DIFF
--- a/src/resolver.test.js
+++ b/src/resolver.test.js
@@ -28,6 +28,7 @@ const FIXTURES = {
     ["dnslink=/skynet-ns/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA"],
     ["skynet-sponsor-key=dummySponsorKey1"],
   ],
+  VALID_SPONSOR: [["skynet-sponsor-key=dummySponsorKey1"]],
   VALID_SKYLINK: [["dnslink=/skynet-ns/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA"]],
 };
 
@@ -63,14 +64,26 @@ describe("Resolver", () => {
       expect(dns.resolveTxt).toHaveBeenCalledWith("_dnslink.skynetlabs.com", expect.any(Function));
     });
 
-    describe("when TXT records contain a valid skylink", () => {
+    describe("when TXT records contain a valid skylink without sponsor", () => {
       beforeEach(() => {
         dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.VALID_SKYLINK));
       });
 
-      it("returns skylink and sponsor properties", async () => {
+      it("returns skylink property", async () => {
         expect(await resolve()).toEqual({
           skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+        });
+      });
+    });
+
+    describe("when TXT records contain a valid sponsor without skylink", () => {
+      beforeEach(() => {
+        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.VALID_SPONSOR));
+      });
+
+      it("returns sponsor property", async () => {
+        expect(await resolve()).toEqual({
+          sponsor: "dummySponsorKey1",
         });
       });
     });

--- a/src/server.e2e.test.js
+++ b/src/server.e2e.test.js
@@ -1,6 +1,5 @@
 const fetch = require("node-fetch");
 const { Server } = require("./server");
-const { Resolver, ResolutionError } = require("./resolver");
 
 describe("End-to-end tests", () => {
   const app = new Server();
@@ -27,6 +26,16 @@ describe("End-to-end tests", () => {
     const response = await fetch("http://0.0.0.0:1235/dnslink/dns-link.skynetlabs.io");
     const expectedResponse = {
       skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+    };
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(expectedResponse);
+  });
+
+  it("wildcard-sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid sponsor key", async () => {
+    const response = await fetch("http://0.0.0.0:1235/dnslink/wildcard-sponsored-dns-link.skynetlabs.io");
+    const expectedResponse = {
+      sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
     };
 
     expect(response.status).toBe(200);


### PR DESCRIPTION
allow defining dnslink record for sponsor without specific skylink, backwards compatible

look at src/server.e2e.test.js for usage example

closes #16