### PR TITLE
new dnslink resolution endpoint with skylink detection from uri

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  resetMocks: true,
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "express": "^4.18.1",
     "is-valid-domain": "^0.1.6",
     "lru-cache": "^7.14.0",
+    "skynet-js": "^4.3.0",
     "winston": "^3.8.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "dependencies": {
     "express": "^4.18.1",
     "is-valid-domain": "^0.1.6",
+    "lru-cache": "^7.14.0",
     "winston": "^3.8.1"
   },
   "devDependencies": {
     "codecov": "^3.8.3",
     "jest": "^28.1.3",
-    "node-fetch": "2",
+    "node-fetch": "^2.6.7",
     "prettier": "^2.7.1"
   },
   "scripts": {

--- a/src/dnsResolveTxt.js
+++ b/src/dnsResolveTxt.js
@@ -1,0 +1,39 @@
+const dns = require("node:dns").promises;
+const LRU = require("lru-cache");
+
+class ResolutionError extends Error {}
+
+const dnsCache = new LRU({
+  max: Number(process.env.DNSLINK_CACHE_SIZE ?? 5000), // defaults to max 5000 cached items
+  ttl: Number(process.env.DNSLINK_CACHE_TIME ?? 1000 * 60 * 5), // defaults to 5 minutes time to live
+});
+
+async function dnsResolveTxt(domain) {
+  if (dnsCache.has(domain)) {
+    return dnsCache.get(domain);
+  }
+
+  try {
+    const addresses = await dns.resolveTxt(domain);
+
+    // only cache successful resolutions
+    dnsCache.set(domain, addresses);
+
+    return addresses;
+  } catch (error) {
+    // if domain name isn't configured with a TXT record, raise an error
+    if (error.code === "ENOTFOUND") {
+      throw new ResolutionError(`ENOTFOUND: ${domain} TXT record doesn't exist`);
+    }
+
+    // if domain name could not be resolved, raise an error
+    if (error.code === "ENODATA") {
+      throw new ResolutionError(`ENODATA: ${domain} dns lookup returned no data`);
+    }
+
+    // if TXT record resolution fails for any other reason, raise an error
+    throw new ResolutionError(`Failed to fetch ${domain} TXT record: ${error.message}`);
+  }
+}
+
+module.exports = { dnsResolveTxt, ResolutionError };

--- a/src/dnsResolveTxt.test.js
+++ b/src/dnsResolveTxt.test.js
@@ -1,0 +1,67 @@
+const dns = require("node:dns").promises;
+const crypto = require("crypto");
+const { dnsResolveTxt } = require("./dnsResolveTxt");
+
+const getRandomDomain = () => crypto.randomBytes(16).toString("hex") + ".com";
+
+describe("dnsResolveTxt", () => {
+  it("throws an error when record does not exist", async () => {
+    const domain = getRandomDomain();
+
+    jest.spyOn(dns, "resolveTxt").mockRejectedValueOnce(Object.assign(new Error(), { code: "ENOTFOUND" }));
+
+    await expect(dnsResolveTxt(domain)).rejects.toEqual(new Error(`ENOTFOUND: ${domain} TXT record doesn't exist`));
+  });
+
+  it("throws an error when lookup returned no data", async () => {
+    const domain = getRandomDomain();
+
+    jest.spyOn(dns, "resolveTxt").mockRejectedValueOnce(Object.assign(new Error(), { code: "ENODATA" }));
+
+    await expect(dnsResolveTxt(domain)).rejects.toEqual(new Error(`ENODATA: ${domain} dns lookup returned no data`));
+  });
+
+  it("throws an error when lookup was rejected with unhandled exception", async () => {
+    const domain = getRandomDomain();
+    const error = "server failure message";
+
+    jest.spyOn(dns, "resolveTxt").mockRejectedValueOnce(new Error(error));
+
+    await expect(dnsResolveTxt(domain)).rejects.toEqual(new Error(`Failed to fetch ${domain} TXT record: ${error}`));
+  });
+
+  it("returns resolved addresses on success", async () => {
+    const domain = getRandomDomain();
+    const adddresses = [["dummy-response"]];
+
+    jest.spyOn(dns, "resolveTxt").mockReturnValueOnce(adddresses);
+
+    await expect(dnsResolveTxt(domain)).resolves.toEqual(adddresses);
+  });
+
+  it("caches successfully resolved data", async () => {
+    const domain = getRandomDomain();
+    const adddresses = [["dummy-response"]];
+
+    jest.spyOn(dns, "resolveTxt").mockReturnValue(adddresses);
+
+    // resolve resolveTxt twice and expect the second call to be cached
+    await expect(dnsResolveTxt(domain)).resolves.toEqual(adddresses);
+    await expect(dnsResolveTxt(domain)).resolves.toEqual(adddresses);
+
+    expect(dns.resolveTxt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache error resolutions", async () => {
+    const domain = getRandomDomain();
+    const error = "server failure message";
+
+    jest.spyOn(dns, "resolveTxt").mockRejectedValue(new Error(error));
+
+    // reject resolveTxt twice and expect the second call not to be cached
+    await expect(dnsResolveTxt(domain)).rejects.toEqual(new Error(`Failed to fetch ${domain} TXT record: ${error}`));
+    await expect(dnsResolveTxt(domain)).rejects.toEqual(new Error(`Failed to fetch ${domain} TXT record: ${error}`));
+
+    expect(dns.resolveTxt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,17 +1,17 @@
-const dns = require("dns");
 const isValidDomain = require("is-valid-domain");
-
+const { dnsResolveTxt } = require("./dnsResolveTxt");
 const logger = require("./logger");
 
 const dnslinkNamespace = "skynet-ns";
 const sponsorNamespace = "skynet-sponsor-key";
 const dnslinkRegExp = new RegExp(`^dnslink=/${dnslinkNamespace}/.+$`);
 const sponsorRegExp = new RegExp(`^${sponsorNamespace}=[a-zA-Z0-9]+$`);
-const dnslinkSkylinkRegExp = new RegExp(`^dnslink=/${dnslinkNamespace}/([a-zA-Z0-9_-]{46}|[a-z0-9]{55})`);
+const skylinkMatcher = "[a-z0-9]{55}|[a-zA-Z0-9-_]{46}";
+const dnslinkSkylinkRegExp = new RegExp(`^dnslink=/${dnslinkNamespace}/(${skylinkMatcher})`);
+const uriSkylinkRegExp = new RegExp(`^/(?<skylink>${skylinkMatcher})(?<path>/.*)?`);
 const hint = `valid example: dnslink=/${dnslinkNamespace}/3ACpC9Umme41zlWUgMQh1fw0sNwgWwyfDDhRQ9Sppz9hjQ`;
 
 class InvalidRequestError extends Error {}
-class ResolutionError extends Error {}
 class NoSkynetDNSLinksFoundError extends Error {}
 class MultipleSkylinksError extends Error {}
 class InvalidSkylinkError extends Error {}
@@ -33,105 +33,82 @@ class Resolver {
    * @property {boolean} [sponsor] - Sponsor key configured for the given domain (if any).
    *
    * @param {string} domain Domain name to be checked for DNS link records.
+   * @param {string} uri Optional uri string passed from the client.
    * @returns {Promise<ResolutionResult>}
    */
-  async resolve(domain) {
+  async resolve(domain, uri) {
     const lookup = `_dnslink.${domain}`;
+    const addresses = await dnsResolveTxt(lookup);
 
-    return new Promise((resolve, reject) => {
-      dns.resolveTxt(lookup, (error, addresses) => {
-        if (error) {
-          // If domain name isn't configured with a TXT record, raise an error
-          if (error.code === "ENOTFOUND") {
-            return reject(new ResolutionError(`ENOTFOUND: ${lookup} TXT record doesn't exist`));
-          }
+    /**
+     * Domain has TXT records configured, but we need to filter out those that don't match our convention
+     * specified by regular expressions above:
+     *  - dnslink=/skynet-ns/<skylink>, or
+     *  - dnslink=/skynet-sponsor-key/<sponsor-key>
+     */
+    const records = addresses.flat();
+    const dnslinkSkylinks = records.filter((record) => dnslinkRegExp.test(record));
+    const dnslinkSponsors = records.filter((record) => sponsorRegExp.test(record));
 
-          // If domain name could not be resolved, raise an error
-          if (error.code === "ENODATA") {
-            return reject(new ResolutionError(`ENODATA: ${lookup} dns lookup returned no data`));
-          }
+    // match a skylink from the uri to use when dnslink does not define one
+    const matchSkylinkUri = uri ? uri.match(uriSkylinkRegExp) : null;
 
-          // If TXT record resolution fails for any other reason, raise an error
-          return reject(new ResolutionError(`Failed to fetch ${lookup} TXT record: ${error.message}`));
-        }
+    // We currently only allow a single skylink to be tied to a domain name.
+    // If there are more skylinks configured, raise an error.
+    if (dnslinkSkylinks.length > 1) {
+      throw new MultipleSkylinksError(
+        `Multiple TXT records with valid skynet dnslink found for ${lookup}, only one allowed`
+      );
+    }
 
-        // The domain name is successfully resolved, but it's not necessarily configured with any TXT records.
-        // Let's validate that before proceeding.
-        if (addresses.length === 0) {
-          return reject(new ResolutionError(`No TXT record found for ${lookup}`));
-        }
+    // We currently only allow a single sponsor key to be configured with a given domain name.
+    // If there are more, raise an error.
+    if (dnslinkSponsors.length > 1) {
+      throw new MultipleSponsorKeyRecordsError(
+        `Multiple TXT records with valid sponsor key found for ${lookup}, only one allowed`
+      );
+    }
 
-        /**
-         * Domain has TXT records configured, but we need to filter out those that don't match our convention
-         * specified by regular expressions above:
-         *  - dnslink=/skynet-ns/<skylink>, or
-         *  - dnslink=/skynet-sponsor-key/<sponsor-key>
-         */
-        const records = addresses.flat();
-        const dnslinkSkylinks = records.filter((record) => dnslinkRegExp.test(record));
-        const dnslinkSponsors = records.filter((record) => sponsorRegExp.test(record));
+    // If there are no dnslink records configured with our namespaces, we raise an error.
+    if (dnslinkSkylinks.length === 0 && dnslinkSponsors.length === 0 && matchSkylinkUri === null) {
+      throw new NoSkynetDNSLinksFoundError(
+        `TXT records for ${lookup} found but none of them contained valid skynet dnslink - ${hint}`
+      );
+    }
 
-        // We currently only allow a single skylink to be tied to a domain name.
-        // If there are more skylinks configured, raise an error.
-        if (dnslinkSkylinks.length > 1) {
-          return reject(
-            new MultipleSkylinksError(
-              `Multiple TXT records with valid skynet dnslink found for ${lookup}, only one allowed`
-            )
-          );
-        }
+    // Prepare response object and default to uri as path if provided
+    const response = { path: uri };
 
-        // We currently only allow a single sponsor key to be configured with a given domain name.
-        // If there are more, raise an error.
-        if (dnslinkSponsors.length > 1) {
-          return reject(
-            new MultipleSponsorKeyRecordsError(
-              `Multiple TXT records with valid sponsor key found for ${lookup}, only one allowed`
-            )
-          );
-        }
+    if (dnslinkSkylinks.length === 1) {
+      const [dnslink] = dnslinkSkylinks;
+      const matchSkylink = dnslink.match(dnslinkSkylinkRegExp);
 
-        // If there are no dnslink records configured with our namespaces, we raise an error.
-        if (dnslinkSkylinks.length === 0 && dnslinkSponsors.length === 0) {
-          return reject(
-            new NoSkynetDNSLinksFoundError(
-              `TXT records for ${lookup} found but none of them contained valid skynet dnslink - ${hint}`
-            )
-          );
-        }
+      // Verify if the configured skylink is valid.
+      if (!matchSkylink) {
+        throw new InvalidSkylinkError(
+          `TXT record with skynet dnslink for ${lookup} contains invalid skylink - ${hint}`
+        );
+      }
 
-        // Prepare response object
-        const response = {};
+      // Add skylink to response object
+      response.skylink = matchSkylink[1];
+    } else if (matchSkylinkUri) {
+      response.skylink = matchSkylinkUri.groups.skylink;
+      response.path = matchSkylinkUri.groups.path ?? "/";
+    }
 
-        if (dnslinkSkylinks.length === 1) {
-          const [dnslinkSkylink] = dnslinkSkylinks;
-          const matchSkylink = dnslinkSkylink.match(dnslinkSkylinkRegExp);
+    if (dnslinkSponsors.length === 1) {
+      // Extract just the key part from the record and add it to response object
+      response.sponsor = dnslinkSponsors[0].substring(dnslinkSponsors[0].indexOf("=") + 1);
+    }
 
-          // Verify if the configured skylink is valid.
-          if (!matchSkylink) {
-            return reject(
-              new InvalidSkylinkError(`TXT record with skynet dnslink for ${lookup} contains invalid skylink - ${hint}`)
-            );
-          }
+    // Prepare logger message with skylink and sponsor key records if they exist
+    const info = [`skylink: ${response.skylink}`, `sponsor: ${response.sponsor}`].filter(Boolean).join(" | ");
 
-          // Add skylink to response object
-          response.skylink = matchSkylink[1];
-        }
+    // Log the response to the console
+    logger.info(`${domain} => ${info}`);
 
-        if (dnslinkSponsors.length === 1) {
-          // Extract just the key part from the record and add it to response object
-          response.sponsor = dnslinkSponsors[0].substring(dnslinkSponsors[0].indexOf("=") + 1);
-        }
-
-        // Prepare logger message with skylink and sponsor key records if they exist
-        const info = [`skylink: ${response.skylink}`, `sponsor: ${response.sponsor}`].filter(Boolean).join(" | ");
-
-        // Log the response to the console
-        logger.info(`${domain} => ${info}`);
-
-        return resolve(response);
-      });
-    });
+    return response;
   }
 
   /**
@@ -153,7 +130,6 @@ class Resolver {
 module.exports = {
   Resolver,
   InvalidRequestError,
-  ResolutionError,
   NoSkynetDNSLinksFoundError,
   MultipleSkylinksError,
   InvalidSkylinkError,

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,4 +1,5 @@
 const isValidDomain = require("is-valid-domain");
+const { convertSkylinkToBase64 } = require("skynet-js");
 const { dnsResolveTxt } = require("./dnsResolveTxt");
 const logger = require("./logger");
 
@@ -95,6 +96,11 @@ class Resolver {
     } else if (matchSkylinkUri) {
       response.skylink = matchSkylinkUri.groups.skylink;
       response.path = matchSkylinkUri.groups.path ?? "/";
+    }
+
+    // convert skylink to base64 if it is base32 encoded (55 characters long)
+    if (response.skylink?.length === 55) {
+      response.skylink = convertSkylinkToBase64(response.skylink);
     }
 
     if (dnslinkSponsors.length === 1) {

--- a/src/resolver.test.js
+++ b/src/resolver.test.js
@@ -1,16 +1,13 @@
-const dns = require("dns");
-const { hasUncaughtExceptionCaptureCallback } = require("process");
+const dns = require("node:dns").promises;
+const crypto = require("crypto");
 const {
   Resolver,
   InvalidRequestError,
-  ResolutionError,
   NoSkynetDNSLinksFoundError,
   MultipleSkylinksError,
   InvalidSkylinkError,
   MultipleSponsorKeyRecordsError,
 } = require("./resolver");
-
-jest.mock("dns");
 
 const FIXTURES = {
   NO_SKYNET_LINKS: [["dnslink=/dummy-namespace/abcd-1234"]],
@@ -32,12 +29,11 @@ const FIXTURES = {
   VALID_SKYLINK: [["dnslink=/skynet-ns/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA"]],
 };
 
-const mockedDnsResolveTxt = (error, addresses) => (lookup, callback) => callback(error, addresses);
-
 describe("Resolver", () => {
   let resolver;
 
-  const resolve = () => resolver.resolve("dummy-domain.com");
+  // each function call resolves unique domain name to avoid cached results
+  const resolve = (uri) => resolver.resolve(`${crypto.randomBytes(16).toString("hex")}.com`, uri);
 
   beforeEach(() => {
     resolver = new Resolver();
@@ -48,25 +44,28 @@ describe("Resolver", () => {
     const VALID_DOMAINS = ["skynetlabs.com", "siasky.net", "skynetlabs.io"];
 
     it.each(INVALID_DOMAINS)("throws for invalid domain (%s)", (domainName) => {
-      expect(() => resolver.validateRequest({ params: { name: domainName } })).toThrow(InvalidRequestError);
+      expect(() => resolver.validateRequest({ params: { name: domainName, encodedUri: "" } })).toThrow(
+        InvalidRequestError
+      );
     });
 
     it.each(VALID_DOMAINS)("throws for invalid domain (%s)", (domainName) => {
-      expect(() => resolver.validateRequest({ params: { name: domainName } })).not.toThrow();
+      expect(() => resolver.validateRequest({ params: { name: domainName, encodedUri: "" } })).not.toThrow();
     });
   });
 
   describe(".resolve", () => {
     it("invokes dns.resolveTxt with proper params", async () => {
-      dns.resolveTxt.mockImplementationOnce(() => {});
+      jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.VALID_SKYLINK);
+
       resolver.resolve("skynetlabs.com");
 
-      expect(dns.resolveTxt).toHaveBeenCalledWith("_dnslink.skynetlabs.com", expect.any(Function));
+      expect(dns.resolveTxt).toHaveBeenCalledWith("_dnslink.skynetlabs.com");
     });
 
     describe("when TXT records contain a valid skylink without sponsor", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.VALID_SKYLINK));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.VALID_SKYLINK);
       });
 
       it("returns skylink property", async () => {
@@ -78,7 +77,7 @@ describe("Resolver", () => {
 
     describe("when TXT records contain a valid sponsor without skylink", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.VALID_SPONSOR));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.VALID_SPONSOR);
       });
 
       it("returns sponsor property", async () => {
@@ -88,9 +87,53 @@ describe("Resolver", () => {
       });
     });
 
+    describe("when uri is set", () => {
+      beforeEach(() => {});
+
+      describe("and there is no skylink in dnslink", () => {
+        beforeEach(() => {
+          jest.spyOn(dns, "resolveTxt").mockResolvedValue([[]]);
+        });
+
+        it("it should return valid skylink from uri", async () => {
+          expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA")).toEqual({
+            path: "/",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+
+        it("it should return valid skylink from uri with path if path is provided", async () => {
+          expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA/foo/bar")).toEqual({
+            path: "/foo/bar",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+      });
+
+      describe("and there is a skylink in dnslink", () => {
+        beforeEach(() => {
+          jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.VALID_SKYLINK);
+        });
+
+        it("it should return valid skylink from dnslink and the skylink as a path", async () => {
+          expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSB")).toEqual({
+            path: "/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSB",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+
+        it("it should return valid skylink from dnslink and the whole uri as a path", async () => {
+          expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSB/foo/bar")).toEqual({
+            path: "/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSB/foo/bar",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+      });
+    });
+
     describe("when TXT records contain a valid skylink with a single sponsor key", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.VALID_SPONSORED_SKYLINK));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.VALID_SPONSORED_SKYLINK);
       });
 
       it("returns skylink and sponsor properties", async () => {
@@ -101,9 +144,19 @@ describe("Resolver", () => {
       });
     });
 
+    describe("when no TXT records are configured", () => {
+      beforeEach(() => {
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue([]);
+      });
+
+      it("throws NoSkynetDNSLinksFoundError", () => {
+        expect(resolve()).rejects.toThrow(NoSkynetDNSLinksFoundError);
+      });
+    });
+
     describe("when TXT records are present, but none of them are skynet dnslinks", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.NO_SKYNET_LINKS));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.NO_SKYNET_LINKS);
       });
 
       it("throws NoSkynetDNSLinksFoundError", () => {
@@ -113,7 +166,7 @@ describe("Resolver", () => {
 
     describe("when TXT records contain multiple skynet dnslinks", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.MULTIPLE_SKYNET_LINKS));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.MULTIPLE_SKYNET_LINKS);
       });
 
       it("throws MultipleSkylinksError", () => {
@@ -123,7 +176,7 @@ describe("Resolver", () => {
 
     describe("when TXT records contain a skynet dnslink with invalid skylink", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.INVALID_SKYLINK));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.INVALID_SKYLINK);
       });
 
       it("throws InvalidSkylinkError", () => {
@@ -133,53 +186,11 @@ describe("Resolver", () => {
 
     describe("when TXT records contain multiple sponsor keys", () => {
       beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, FIXTURES.MULTIPLE_SPONSOR_KEY));
+        jest.spyOn(dns, "resolveTxt").mockResolvedValue(FIXTURES.MULTIPLE_SPONSOR_KEY);
       });
 
       it("throws MultipleSponsorKeyRecordsError", () => {
         expect(resolve()).rejects.toThrow(MultipleSponsorKeyRecordsError);
-      });
-    });
-
-    describe("when no records are configured", () => {
-      beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt(null, []));
-      });
-
-      it("throws ResolutionError", () => {
-        expect(resolve()).rejects.toThrow(ResolutionError);
-      });
-    });
-
-    describe("when TXT record is not found", () => {
-      beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt({ code: "ENOTFOUND" }));
-      });
-
-      it("throws ResolutionError", () => {
-        expect(resolve()).rejects.toThrow(ResolutionError);
-      });
-    });
-
-    describe("when lookup returns no data", () => {
-      beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(mockedDnsResolveTxt({ code: "ENODATA" }));
-      });
-
-      it("throws ResolutionError", () => {
-        expect(resolve()).rejects.toThrow(ResolutionError);
-      });
-    });
-
-    describe("when lookup returns an error", () => {
-      beforeEach(() => {
-        dns.resolveTxt.mockImplementationOnce(
-          mockedDnsResolveTxt({ code: "any other error", message: "dummy message" })
-        );
-      });
-
-      it("throws ResolutionError", () => {
-        expect(resolve()).rejects.toThrow(ResolutionError);
       });
     });
   });

--- a/src/resolver.test.js
+++ b/src/resolver.test.js
@@ -95,15 +95,29 @@ describe("Resolver", () => {
           jest.spyOn(dns, "resolveTxt").mockResolvedValue([[]]);
         });
 
-        it("it should return valid skylink from uri", async () => {
+        it("it should return valid skylink from uri with base64 skylink", async () => {
           expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA")).toEqual({
             path: "/",
             skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
           });
         });
 
-        it("it should return valid skylink from uri with path if path is provided", async () => {
+        it("it should return valid skylink from uri with base32 skylink", async () => {
+          expect(await resolve("/0409g27kkp4cfpj66e52qvhjk60sej6ia1dmemim0pr3qej404gmai0")).toEqual({
+            path: "/",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+
+        it("it should return valid skylink from uri with base64 skylink with path if path is provided", async () => {
           expect(await resolve("/AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA/foo/bar")).toEqual({
+            path: "/foo/bar",
+            skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
+          });
+        });
+
+        it("it should return valid skylink from uri with base32 skylink path if path is provided", async () => {
+          expect(await resolve("/0409g27kkp4cfpj66e52qvhjk60sej6ia1dmemim0pr3qej404gmai0/foo/bar")).toEqual({
             path: "/foo/bar",
             skylink: "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA",
           });

--- a/src/server.e2e.test.js
+++ b/src/server.e2e.test.js
@@ -15,50 +15,110 @@ describe("End-to-end tests", () => {
   /**
    * This section of tests is performed on actual, live domains (these are not mocked).
    */
-  it("no-dns-link.skynetlabs.io - no dnslink entry", async () => {
-    const response = await fetch("http://0.0.0.0:1235/dnslink/no-dns-link.skynetlabs.io");
-    expect(response.status).toBe(400);
-    expect(response.headers.get("content-type")).toEqual("text/plain; charset=utf-8");
-    expect(await response.text()).toEqual("ENOTFOUND: _dnslink.no-dns-link.skynetlabs.io TXT record doesn't exist");
+
+  describe("/dnslink/:name", () => {
+    it("no-dns-link.skynetlabs.io - no dnslink entry", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/no-dns-link.skynetlabs.io");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toEqual("text/plain; charset=utf-8");
+      expect(await response.text()).toEqual("ENOTFOUND: _dnslink.no-dns-link.skynetlabs.io TXT record doesn't exist");
+    });
+
+    it("dns-link.skynetlabs.io - dnslink entry correct with valid skylink", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/dns-link.skynetlabs.io");
+      const expectedResponse = {
+        skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+      };
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
+
+    it("wildcard-sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid sponsor key", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/wildcard-sponsored-dns-link.skynetlabs.io");
+      const expectedResponse = {
+        sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
+      };
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
+
+    it("sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid skylink and sponsor key", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/sponsored-dns-link.skynetlabs.io");
+      const expectedResponse = {
+        skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+        sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
+      };
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
+
+    it("malformed-dns-link.skynetlabs.io - dns entry correct but skylink invalid", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/malformed-dns-link.skynetlabs.io");
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toMatch(
+        /TXT record with skynet dnslink for _dnslink.malformed-dns-link.skynetlabs.io contains invalid skylink/
+      );
+    });
   });
 
-  it("dns-link.skynetlabs.io - dnslink entry correct with valid skylink", async () => {
-    const response = await fetch("http://0.0.0.0:1235/dnslink/dns-link.skynetlabs.io");
-    const expectedResponse = {
-      skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
-    };
+  describe("/dnslink/:name:/:encodedUri", () => {
+    it("no-dns-link.skynetlabs.io - no dnslink entry", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/no-dns-link.skynetlabs.io/Lw==");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toEqual("text/plain; charset=utf-8");
+      expect(await response.text()).toEqual("ENOTFOUND: _dnslink.no-dns-link.skynetlabs.io TXT record doesn't exist");
+    });
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(expectedResponse);
-  });
+    it("dns-link.skynetlabs.io - dnslink entry correct with valid skylink", async () => {
+      const encodedUri = Buffer.from("/").toString("base64");
+      const response = await fetch("http://0.0.0.0:1235/dnslink/dns-link.skynetlabs.io/Lw==");
+      const expectedResponse = {
+        path: "/",
+        skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+      };
 
-  it("wildcard-sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid sponsor key", async () => {
-    const response = await fetch("http://0.0.0.0:1235/dnslink/wildcard-sponsored-dns-link.skynetlabs.io");
-    const expectedResponse = {
-      sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
-    };
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(expectedResponse);
-  });
+    it("wildcard-sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid sponsor key", async () => {
+      const encodedUri = Buffer.from("/MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ").toString("base64");
+      const response = await fetch(
+        `http://0.0.0.0:1235/dnslink/wildcard-sponsored-dns-link.skynetlabs.io/${encodedUri}`
+      );
+      const expectedResponse = {
+        path: "/",
+        skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+        sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
+      };
 
-  it("sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid skylink and sponsor key", async () => {
-    const response = await fetch("http://0.0.0.0:1235/dnslink/sponsored-dns-link.skynetlabs.io");
-    const expectedResponse = {
-      skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
-      sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
-    };
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(expectedResponse);
-  });
+    it("sponsored-dns-link.skynetlabs.io - dnslink entry correct with valid skylink and sponsor key", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/sponsored-dns-link.skynetlabs.io/Lw==");
+      const expectedResponse = {
+        path: "/",
+        skylink: "MABdWWku6YETM2zooGCjQi26Rs4a6Hb74q26i-vMMcximQ",
+        sponsor: "JDCLOJIJ7NJRSN4QRD7EDFVNP7MPJ24O856D57NE3FV2PFBAT6T0",
+      };
 
-  it("malformed-dns-link.skynetlabs.io - dns entry correct but skylink invalid", async () => {
-    const response = await fetch("http://0.0.0.0:1235/dnslink/malformed-dns-link.skynetlabs.io");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedResponse);
+    });
 
-    expect(response.status).toBe(400);
-    expect(await response.text()).toMatch(
-      /TXT record with skynet dnslink for _dnslink.malformed-dns-link.skynetlabs.io contains invalid skylink/
-    );
+    it("malformed-dns-link.skynetlabs.io - dns entry correct but skylink invalid", async () => {
+      const response = await fetch("http://0.0.0.0:1235/dnslink/malformed-dns-link.skynetlabs.io/Lw==");
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toMatch(
+        /TXT record with skynet dnslink for _dnslink.malformed-dns-link.skynetlabs.io contains invalid skylink/
+      );
+    });
   });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-
 const logger = require("./logger");
 const { Resolver } = require("./resolver");
 
@@ -17,6 +16,7 @@ class Server {
    * Configures routing
    */
   configure() {
+    // domain is full name of the domain pointing at the server
     this.app.get("/dnslink/:name", async (req, res) => {
       const domainName = req.params.name;
 
@@ -26,6 +26,25 @@ class Server {
         const { skylink, sponsor } = await this.resolver.resolve(domainName);
 
         res.json({ skylink, sponsor });
+      } catch (error) {
+        logger.error(error.message);
+        // Set content-type to text/plain to prevent XSS attacks.
+        res.status(400).contentType("text/plain; charset=utf-8").send(error.message);
+      }
+    });
+
+    // domain is full name of the domain pointing at the server
+    // encodedUri is base64 encoded uri string passed from nginx
+    this.app.get("/dnslink/:name/:encodedUri", async (req, res) => {
+      const domainName = req.params.name;
+
+      try {
+        this.resolver.validateRequest(req);
+
+        const uri = Buffer.from(req.params.encodedUri, "base64").toString();
+        const response = await this.resolver.resolve(domainName, uri);
+
+        res.json(response);
       } catch (error) {
         logger.error(error.message);
         // Set content-type to text/plain to prevent XSS attacks.

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -1,6 +1,6 @@
 const fetch = require("node-fetch");
 const { Server } = require("./server");
-const { Resolver, ResolutionError } = require("./resolver");
+const { ResolutionError } = require("./dnsResolveTxt");
 
 describe("Server", () => {
   const app = new Server();
@@ -17,7 +17,7 @@ describe("Server", () => {
     describe("when domain is configured with a skylink", () => {
       const configuredSkylink = "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA";
 
-      beforeAll(() => {
+      beforeEach(() => {
         jest.spyOn(app.resolver, "validateRequest").mockImplementation(() => {});
         jest.spyOn(app.resolver, "resolve").mockResolvedValue({ skylink: configuredSkylink });
       });
@@ -36,7 +36,7 @@ describe("Server", () => {
       const configuredSkylink = "AQCYCPSmSMfmZjOKLX4zoYHHTNJQW2daVgZ2PTpkASFlSA";
       const configuredSponsorKey = "sponsor-key-1234";
 
-      beforeAll(() => {
+      beforeEach(() => {
         jest.spyOn(app.resolver, "validateRequest").mockImplementation(() => {});
         jest.spyOn(app.resolver, "resolve").mockResolvedValue({
           skylink: configuredSkylink,
@@ -56,7 +56,7 @@ describe("Server", () => {
     });
 
     describe("when domain is not configured with a skylink ", () => {
-      beforeAll(() => {
+      beforeEach(() => {
         jest.spyOn(app.resolver, "validateRequest").mockImplementation(() => {});
         jest
           .spyOn(app.resolver, "resolve")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,6 +1987,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
+  integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -2095,7 +2100,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-fetch@2, node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,6 +574,19 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@skynetlabs/tus-js-client@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@skynetlabs/tus-js-client/-/tus-js-client-2.4.1.tgz#01e70e8c92fb3ec043b0c7da5206d7b96149c162"
+  integrity sha512-cc//2XeIqfZQ7rC182MbMwx/xTh1Cw1mQb2BmeHh6rO+coioyUSX71znPCsvijdKM+3NYXbhg5r/ZV5028OXfg==
+  dependencies:
+    buffer-from "^1.1.2"
+    combine-errors "^3.0.3"
+    is-stream "^2.0.0"
+    js-base64 "^2.6.1"
+    lodash.throttle "^4.1.1"
+    proper-lockfile "^2.0.1"
+    url-parse "^1.5.7"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -736,10 +749,30 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
+async-mutex@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-jest@^28.1.3:
   version "28.1.3"
@@ -806,6 +839,28 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base32-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base32-decode/-/base32-decode-1.0.0.tgz#2a821d6a664890c872f20aa9aca95a4b4b80e2a7"
+  integrity sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g==
+
+base32-encode@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/base32-encode/-/base32-encode-1.2.0.tgz#e150573a5e431af0a998e32bdfde7045725ca453"
+  integrity sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==
+  dependencies:
+    to-data-view "^1.1.0"
+
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+blakejs@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
+  integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
+
 body-parser@1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
@@ -857,10 +912,18 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@^1.0.0, buffer-from@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -1005,6 +1068,21 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
+combine-errors@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/combine-errors/-/combine-errors-3.0.3.tgz#f4df6740083e5703a3181110c2b10551f003da86"
+  integrity sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==
+  dependencies:
+    custom-error-instance "2.1.1"
+    lodash.uniqby "4.5.0"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1048,6 +1126,11 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+custom-error-instance@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/custom-error-instance/-/custom-error-instance-2.1.1.tgz#3cf6391487a6629a6247eb0ca0ce00081b7e361a"
+  integrity sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1071,6 +1154,11 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0:
   version "2.0.0"
@@ -1284,6 +1372,20 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -1355,7 +1457,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -1426,6 +1528,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-walk@3.0.4:
   version "3.0.4"
@@ -1914,6 +2021,11 @@ jest@^28.1.3:
     import-local "^3.0.2"
     jest-cli "^28.1.3"
 
+js-base64@^2.6.1:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
+  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1968,6 +2080,56 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash._baseiteratee@~4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz#34a9b5543572727c3db2e78edae3c0e9e66bd102"
+  integrity sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==
+  dependencies:
+    lodash._stringtopath "~4.8.0"
+
+lodash._basetostring@~4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz#9327c9dc5158866b7fa4b9d42f4638e5766dd9df"
+  integrity sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw==
+
+lodash._baseuniq@~4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
+  integrity sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==
+  dependencies:
+    lodash._createset "~4.0.0"
+    lodash._root "~3.0.0"
+
+lodash._createset@~4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
+  integrity sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==
+
+lodash._root@~3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
+  integrity sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ==
+
+lodash._stringtopath@~4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz#941bcf0e64266e5fc1d66fed0a6959544c576824"
+  integrity sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==
+  dependencies:
+    lodash._basetostring "~4.12.0"
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
+
+lodash.uniqby@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz#a3a17bbf62eeb6240f491846e97c1c4e2a5e1e21"
+  integrity sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==
+  dependencies:
+    lodash._baseiteratee "~4.7.0"
+    lodash._baseuniq "~4.6.0"
 
 logform@^2.3.2, logform@^2.4.0:
   version "2.4.0"
@@ -2044,6 +2206,18 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime-types@~2.1.24:
   version "2.1.31"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
@@ -2062,6 +2236,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -2203,6 +2382,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2250,6 +2434,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+post-me@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/post-me/-/post-me-0.4.5.tgz#6171b721c7b86230c51cfbe48ddea047ef8831ce"
+  integrity sha512-XgPdktF/2M5jglgVDULr9NUb/QNv3bY3g6RG22iTb5MIMtB07/5FJB5fbVmu5Eaopowc6uZx7K3e7x1shPwnXw==
+
 prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
@@ -2272,6 +2461,14 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proper-lockfile@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-2.0.1.tgz#159fb06193d32003f4b3691dd2ec1a634aa80d1d"
+  integrity sha512-rjaeGbsmhNDcDInmwi4MuI6mRwJu6zq8GjYCLuSuE7GF+4UjgzkL69sVKKJ2T2xH61kK7rXvGYpvaTu909oXaQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+    retry "^0.10.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -2297,6 +2494,18 @@ qs@6.10.3:
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -2332,6 +2541,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -2358,6 +2572,11 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -2365,7 +2584,7 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2468,6 +2687,41 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+sjcl@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/sjcl/-/sjcl-1.0.8.tgz#f2ec8d7dc1f0f21b069b8914a41a8f236b0e252a"
+  integrity sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==
+
+skynet-js@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.3.0.tgz#57d471dfb3ffc0f2e4c8d370a888b0498f8f6d4a"
+  integrity sha512-fkaKqHCheQ6tseL7keEU7v5IxwAlfROMMMYPcbo64n9SHfsVXjPmW5wowc6OgmpB5Mt5k4EMVlIrGqF2VbizIw==
+  dependencies:
+    "@skynetlabs/tus-js-client" "^2.4.1"
+    async-mutex "^0.3.2"
+    axios "^0.27.2"
+    base32-decode "^1.0.0"
+    base32-encode "^1.1.1"
+    base64-js "^1.3.1"
+    blakejs "^1.1.0"
+    buffer "^6.0.1"
+    mime "^3.0.0"
+    path-browserify "^1.0.1"
+    post-me "^0.4.5"
+    randombytes "^2.1.0"
+    sjcl "^1.0.8"
+    skynet-mysky-utils "^0.3.0"
+    tweetnacl "^1.0.3"
+    url-join "^4.0.1"
+    url-parse "^1.5.1"
+
+skynet-mysky-utils@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/skynet-mysky-utils/-/skynet-mysky-utils-0.3.1.tgz#58aa8f4caeca0ddea472211fb40f19bd6aa25b1e"
+  integrity sha512-UO9U1LUjwn+E8N1CV2iVJbl0VhVVKPwcOSTzgP9thX8Qp/zT+/+TVb1JTimqbd8+/gZhaP8BzrnmgRs6EVtFxA==
+  dependencies:
+    post-me "^0.4.5"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -2639,6 +2893,11 @@ tmpl@1.0.5:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
+to-data-view@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/to-data-view/-/to-data-view-1.1.0.tgz#08d6492b0b8deb9b29bdf1f61c23eadfa8994d00"
+  integrity sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -2666,6 +2925,16 @@ triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
@@ -2688,6 +2957,19 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
+url-parse@^1.5.1, url-parse@^1.5.7:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 urlgrey@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
note: this pull request is backwards compatible, it introduces new endpoint that handles requests with uri included

- introduces locally cached dns resolutions to limit number of calls
- new endpoint /dnslink/:name/:encodedUri
  - encodedUri is a base64 encoded uri passed from nginx, it always starts with /
  - endpoint always returns skylink and path props on success, sponor prop optionally
  - allows to dramatically simplify logic in nginx to just read skylink and path on success and pass them to skyd